### PR TITLE
fix: use gio open instead of xdg-open to honor Terminal=true apps

### DIFF
--- a/Find.qml
+++ b/Find.qml
@@ -366,11 +366,19 @@ Item {
     resultList.positionViewAtIndex(root.selectedIndex, ListView.Contain)
   }
 
+  // Prefer gio (honors Terminal=true .desktop entries by launching them
+  // inside a terminal), falling back to xdg-open when gio is unavailable.
+  function openPath(path) {
+    var quoted = Util.shellQuote(path)
+    Quickshell.execDetached(["bash", "-c",
+      "command -v gio >/dev/null 2>&1 && exec gio open " + quoted + " || exec xdg-open " + quoted])
+  }
+
   function activateIndex(index) {
     if (index < 0 || index >= displayModel.count) return
     var row = displayModel.get(index)
     root.dismiss()
-    Quickshell.execDetached(["xdg-open", row.path])
+    root.openPath(row.path)
   }
 
   function openEnclosingFolder(index) {
@@ -378,7 +386,7 @@ Item {
     var row = displayModel.get(index)
     root.dismiss()
     var target = row.isDir ? row.path : (row.path.slice(0, row.path.lastIndexOf("/")) || root.home)
-    Quickshell.execDetached(["xdg-open", target])
+    root.openPath(target)
   }
 
   function copyPathToClipboard(index) {


### PR DESCRIPTION
## Problem

Pressing Enter on a file whose default handler is a terminal-based app (e.g. a text/code file when the default editor is `nvim`, which Omarchy ships by default) does nothing — no window, no error, no visible effect.

## Root cause

`activateIndex`/`openEnclosingFolder` call `Quickshell.execDetached(["xdg-open", path])`. `xdg-open` (xdg-utils) never reads the `Terminal=` key from the resolved `.desktop` entry — it always execs the target command directly. For a GUI app that's fine, but for a TUI app like `nvim` (`nvim.desktop` has `Terminal=true`) it tries to start ncurses with no TTY attached. Since the process is spawned via `execDetached` (no controlling terminal, no captured stdout/stderr), it fails to initialize and exits immediately with nothing visible to the user.

This isn't machine-specific: since Omarchy ships `nvim` as the default text editor out of the box, any user who hasn't switched to a GUI editor will hit this exact "Enter does nothing" behavior on text/code files.

## Fix

Use `gio open` (GLib/GIO, already present on any GTK-adjacent desktop, which Omarchy is) instead. `gio`'s `GDesktopAppInfo` correctly reads `Terminal=` and, when set, wraps the launch in the user's configured terminal emulator — while still launching GUI apps directly with no behavior change there. Falls back to `xdg-open` if `gio` isn't present on someone's system.

Verified manually: `xdg-open somefile.txt` (default app `nvim.desktop`, `Terminal=true`) silently exits with no output. `gio open somefile.txt` spawns the configured terminal (`ghostty -e nvim somefile.txt` here) with a working nvim session.

## Change

Both call sites now go through a small `openPath()` helper:
```qml
function openPath(path) {
  var quoted = Util.shellQuote(path)
  Quickshell.execDetached(["bash", "-c",
    "command -v gio >/dev/null 2>&1 && exec gio open " + quoted + " || exec xdg-open " + quoted])
}
```