### PR TITLE
feat(ai): add Pi agent adapter for AI search mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ By default, Omarchy Find automatically detects and uses the default AI agent con
 | **OpenCode** (`opencode`) | ✅ Fully supported (automatic streaming & terminal handoff) |
 | **Claude Code** (`claude`) | ✅ Fully supported (automatic streaming & terminal handoff) |
 | **Codex** (`codex`) | ✅ Fully supported (automatic streaming & terminal handoff) |
+| **Pi** (`pi`) | ✅ Fully supported (automatic streaming & terminal handoff) |
 
 #### Setting the Omarchy Default Agent
 
@@ -63,6 +64,11 @@ You can set your default agent using the Omarchy CLI or directly via shell:
   echo "opencode" > ~/.config/omarchy/defaults/agent
   ```
   *(Or via `omarchy default agent opencode`)*
+- **Set to Pi (`pi`):**
+  ```sh
+  echo "pi" > ~/.config/omarchy/defaults/agent
+  ```
+  *(Or via `omarchy default agent pi`)*
 
 Omarchy Find hot-reloads this change live in real time without requiring a shell restart.
 
@@ -84,7 +90,7 @@ If you wish to use a different agent specifically inside Omarchy Find (for examp
 
 ```json
 {
-  "agent": "agy",          // "agy" | "opencode" | "claude" | "codex"
+  "agent": "agy",          // "agy" | "opencode" | "claude" | "codex" | "pi"
   "model": null,           // Override model string (e.g. "opencode-go/qwen3.8-flash") or null for CLI default
   "prefix": "ai ",         // Trigger prefix in the overlay
   "maxAnswerRows": 6       // Maximum visible answer lines before scrolling

--- a/ai/AiAdapters.js
+++ b/ai/AiAdapters.js
@@ -488,11 +488,123 @@ var opencodeAdapter = {
   }
 }
 
+// -------------------------------------------------------------------- Pi ---
+
+var piAdapter = {
+  id: "pi",
+  label: "Pi",
+  binary: "pi",
+  capabilities: {
+    // The session id lands in the very first NDJSON event and `pi
+    // --session-id <id>` resumes it from the same working directory — see
+    // the buildResume note below for the project-scoping caveat.
+    continuity: "returned-id",
+    modelOverride: true,
+    webSearchDetection: false,
+    resumeBeforeExit: false
+  },
+
+  createSessionRef: function() { return null },
+
+  // Verified against real `pi -p '<prompt>' --mode json` runs: the prompt
+  // must be the argv element immediately following -p (same value-taking
+  // gotcha as agy's --print — a trailing positional after other options is
+  // likewise bound correctly, but keeping -p+prompt adjacent removes any
+  // ambiguity). Options are grouped BEFORE -p so --model can never be
+  // mistaken for the prompt value.
+  buildRun: function(prompt, sessionRef, config) {
+    var argv = ["pi", "--mode", "json"]
+    if (config && config.model) argv.push("--model", config.model)
+    argv.push("-p", prompt)
+    return argv
+  },
+
+  // pi scopes session files per project (working directory). The overlay
+  // spawns the agent with quickshell's cwd and xdg-terminal-exec resumes
+  // with --dir=$HOME, and quickshell runs from $HOME (its service cwd), so
+  // both sides resolve to the same project and the exact --session-id
+  // lookup finds the file the headless run saved. If the shell were ever
+  // started from elsewhere, resume would open a fresh session for that id
+  // instead — same class of limitation as any per-project session store.
+  buildResume: function(sessionRef, config) {
+    var argv = ["pi", "--session-id", sessionRef]
+    if (config && config.model) argv.push("--model", config.model)
+    return argv
+  },
+
+  // NDJSON schema captured from real `pi -p ... --mode json` runs:
+  //   {"type":"session","id":"01a0...","cwd":"/home/user"}
+  //   {"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":1,"delta":"Hello"}}
+  //   {"type":"turn_end","message":{...}} / {"type":"agent_end","messages":[...]}
+  // text_delta events are already incremental (unlike codex's full-text
+  // item updates) so each is emitted as-is. thinking/toolcall deltas are
+  // surfaced as activity only, never as answer text. The authoritative
+  // final answer lives in turn_end/agent_end message content — kept as a
+  // fallback for AiBackend's defense-in-depth, never the primary path.
+  parseLine: function(line, ps) {
+    var obj = safeParse(line)
+    if (obj === undefined || obj === null || typeof obj !== "object") return []
+    var events = []
+    var type = obj.type
+
+    if (type === "session") {
+      if (!ps.sessionCaptured && typeof obj.id === "string" && obj.id.length > 0) {
+        ps.sessionCaptured = true
+        events.push({ type: "session", sessionRef: obj.id })
+      }
+      return events
+    }
+
+    if (type === "turn_start") {
+      ps.turnIndex = (ps.turnIndex || 0) + 1
+      events.push({ type: "activity", activity: "thinking" })
+      return events
+    }
+
+    if (type === "message_update" && obj.assistantMessageEvent && typeof obj.assistantMessageEvent === "object") {
+      var se = obj.assistantMessageEvent
+      if (se.type === "text_delta" && typeof se.delta === "string" && se.delta.length > 0) {
+        events.push({ type: "text", text: se.delta })
+      } else if (se.type === "thinking_start" || se.type === "thinking_delta" ||
+                 se.type === "toolcall_start" || se.type === "toolcall_delta") {
+        events.push({ type: "activity", activity: "thinking" })
+      }
+      return events
+    }
+
+    if (type === "turn_end" || type === "agent_end") {
+      // turn_end -> obj.message (assistant message); agent_end ->
+      // obj.messages (conversation array, last entry is the assistant
+      // reply). Concatenate the type:"text" content parts only — thinking
+      // and tool-call payloads never leak into the answer fallback.
+      var msg = (type === "agent_end" && Array.isArray(obj.messages))
+        ? obj.messages[obj.messages.length - 1]
+        : obj.message
+      if (msg && Array.isArray(msg.content)) {
+        var full = ""
+        for (var i = 0; i < msg.content.length; i++) {
+          var part = msg.content[i]
+          if (part && part.type === "text" && typeof part.text === "string") full += part.text
+        }
+        if (full.length > 0) ps.finalText = full
+      }
+      return events
+    }
+
+    return events
+  },
+
+  classifyFailure: function(exitCode, stderrText) {
+    return classifyGeneric(stderrText)
+  }
+}
+
 var ADAPTERS = {
   claude: claudeAdapter,
   codex: codexAdapter,
   agy: agyAdapter,
-  opencode: opencodeAdapter
+  opencode: opencodeAdapter,
+  pi: piAdapter
 }
 
 function get(id) {

--- a/ai/AiBackend.js
+++ b/ai/AiBackend.js
@@ -141,14 +141,14 @@ function beginGeneration(promptText) {
     // default-agent system but that don't yet have a headless adapter here.
     // This is far better UX than a generic "unsupported agent" error that
     // implies the user made a mistake in ai.json.
-    var knownOmarchyAgents = ["gemini", "copilot", "grok", "pi", "omp", "crush"]
+    var knownOmarchyAgents = ["gemini", "copilot", "grok", "omp", "crush"]
     var isKnownOmarchy = knownOmarchyAgents.indexOf(runtimeConfig.agent) !== -1
     var errorMsg = isKnownOmarchy
       ? runtimeConfig.agent + " does not yet support headless AI mode. " +
-        "Switch your Omarchy agent to claude, codex, or opencode, or create " +
-        "~/.config/omarchy-find/ai.json with {\"agent\": \"opencode\"}."
+        "Switch your Omarchy agent to claude, codex, agy, opencode, or pi " +
+        "(or create ~/.config/omarchy-find/ai.json with one of those agents)."
       : "Unsupported agent \"" + runtimeConfig.agent + "\" — check ai.json. " +
-        "Supported agents: claude, codex, agy, opencode."
+        "Supported agents: claude, codex, agy, opencode, pi."
     session = {
       generation: gen,
       adapterId: runtimeConfig.agent,

--- a/ai/AiConfig.js
+++ b/ai/AiConfig.js
@@ -7,7 +7,7 @@
 // (or null/undefined when the file does not exist) and we hand back a
 // complete, valid runtime config plus an optional short warning string.
 
-var SUPPORTED_AGENTS = ["claude", "codex", "agy", "opencode"]
+var SUPPORTED_AGENTS = ["claude", "codex", "agy", "opencode", "pi"]
 
 // The streaming "typewriter" reveal (see ai/AiBackend.js's tick()) is an
 // exponential RAMP over time — the rate never depends on how much text is

--- a/tests/ai_unit_test.js
+++ b/tests/ai_unit_test.js
@@ -151,7 +151,7 @@ function drainToReady(maxTicks) {
 
 // argv safety: prompt must always be a single literal argv element, never
 // concatenated into another string, for every adapter.
-for (const id of ["claude", "codex", "agy", "opencode"]) {
+for (const id of ["claude", "codex", "agy", "opencode", "pi"]) {
   const adapter = AiAdapters.get(id)
   assert(adapter !== null, "adapter registered: " + id)
   const nasty = "\"'; $(echo hi) `uname` | ; \n中文 🚀"
@@ -314,8 +314,59 @@ for (const id of ["claude", "codex", "agy", "opencode"]) {
 }
 
 {
+  // Pi: argv order, NDJSON event shapes, and session-continuity semantics
+  // verified against real `pi -p ... --mode json` runs (the session event's
+  // id is the ONLY authoritative sessionRef; text_delta events are already
+  // incremental; thinking/toolcall deltas stay activity-only; turn_end and
+  // agent_end both carry the full answer for the finalText fallback).
+  const adapter = AiAdapters.get("pi")
+  assert(adapter !== null, "pi adapter registered")
+
+  const argv = adapter.buildRun("hello", null, AiConfig.defaults())
+  const pIdx = argv.indexOf("-p")
+  eq(argv[pIdx + 1], "hello", "pi buildRun binds the prompt as -p's own value (value-taking, like agy's --print)")
+  assert(argv.indexOf("--mode") !== -1 && argv[argv.indexOf("--mode") + 1] === "json", "pi buildRun streams NDJSON events")
+  const argvModel = adapter.buildRun("hello", null, { model: "opencode-go/qwen3.8-flash" })
+  assert(argvModel.indexOf("--model") !== -1 && argvModel.indexOf("opencode-go/qwen3.8-flash") !== -1, "pi buildRun with explicit model includes --model")
+  assert(argvModel.indexOf("--model") < argvModel.indexOf("-p"), "pi buildRun groups options before -p so --model can never be read as the prompt")
+
+  const resumeArgv = adapter.buildResume("01a0736b-5551-7689-99ae-b04e08489f3a", AiConfig.defaults())
+  eq(resumeArgv[0], "pi", "pi buildResume calls the pi binary")
+  assert(resumeArgv.indexOf("--session-id") !== -1 && resumeArgv.indexOf("01a0736b-5551-7689-99ae-b04e08489f3a") !== -1, "pi buildResume resumes the exact session id")
+  const resumeArgvModel = adapter.buildResume("sess-x", { model: "opencode/hy3-free" })
+  assert(resumeArgvModel.indexOf("--model") !== -1 && resumeArgvModel.indexOf("opencode/hy3-free") !== -1, "pi buildResume with explicit model includes --model")
+
+  const ps = {}
+  let text = ""
+  let sawSession = null
+  const lines = [
+    '{"type":"session","version":3,"id":"01a0736b-5551-7689-99ae-b04e08489f3a","timestamp":"2026-09-05T21:13:29.170Z","cwd":"/home/mark"}',
+    '{"type":"turn_start"}',
+    '{"type":"message_update","usage":{},"assistantMessageEvent":{"type":"thinking_start","contentIndex":0}}',
+    '{"type":"message_update","usage":{},"assistantMessageEvent":{"type":"thinking_delta","contentIndex":0,"delta":"The user wants exactly"}}',
+    '{"type":"message_update","usage":{},"assistantMessageEvent":{"type":"text_delta","contentIndex":1,"delta":"Hello"}}',
+    '{"type":"message_update","usage":{},"assistantMessageEvent":{"type":"toolcall_delta","contentIndex":2,"delta":"{\"cmd\":\"echo\"}"}}',
+    '{"type":"message_update","usage":{},"assistantMessageEvent":{"type":"text_delta","contentIndex":1,"delta":" world"}}',
+    '{"type":"turn_end","message":{"role":"assistant","content":[{"type":"thinking","thinking":"..."},{"type":"text","text":"Hello world"}],"stopReason":"stop"},"toolResults":[]}',
+    '{"type":"agent_end","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]},{"role":"assistant","content":[{"type":"thinking","thinking":"..."},{"type":"text","text":"Hello world"}]}],"willRetry":false}'
+  ]
+  for (const line of lines) {
+    for (const ev of adapter.parseLine(line, ps)) {
+      if (ev.type === "text") text += ev.text
+      if (ev.type === "session") sawSession = ev.sessionRef
+    }
+  }
+  eq(sawSession, "01a0736b-5551-7689-99ae-b04e08489f3a", "pi adapter captures the session id from the session event")
+  eq(text, "Hello world", "pi adapter reconstructs streamed text from text_delta events only — thinking and toolcall deltas are never answer text")
+  eq(ps.finalText, "Hello world", "pi adapter stashes the agent_end full text as a fallback")
+
+  const cls = adapter.classifyFailure(1, "error: API key not configured")
+  assert(cls && cls.kind === "auth", "pi classifyFailure routes auth stderr through the generic classifier")
+}
+
+{
   // Malformed JSON / unknown event types must never throw for any adapter.
-  for (const id of ["claude", "codex", "agy", "opencode"]) {
+  for (const id of ["claude", "codex", "agy", "opencode", "pi"]) {
     const adapter = AiAdapters.get(id)
     let threw = false
     try {
@@ -558,6 +609,39 @@ for (const id of ["claude", "codex", "agy", "opencode"]) {
   const resumeArgv = AiBackend.buildHandoffArgv()
   assert(resumeArgv.indexOf("server-assigned-id") !== -1, "handoff argv resumes the server-confirmed id, not the caller guess")
   assert(resumeArgv.indexOf(callerUuid) === -1, "handoff argv never references the stale caller uuid")
+}
+
+{
+  // Pi end-to-end: the real NDJSON shape (session event first, incremental
+  // text_delta events, thinking/toolcall deltas never surfaced as text,
+  // agent_end carrying the authoritative full answer) through the whole
+  // AiBackend pipeline to a handoff that resumes the captured session id.
+  AiBackend.loadConfig(JSON.stringify({ agent: "pi" }))
+  AiBackend.cancel()
+  const g = AiBackend.beginGeneration("pi e2e test")
+  assert(Array.isArray(g.argv), "pi generation produces an argv")
+  assert(g.argv[0] === "setsid", "pi argv is process-group wrapped like every adapter")
+  const pIdx = g.argv.indexOf("-p")
+  assert(pIdx !== -1 && g.argv[pIdx + 1] === "pi e2e test", "pi buildRun binds the prompt as -p's own value")
+  eq(g.argv[g.argv.indexOf("--mode") + 1], "json", "pi buildRun streams NDJSON events")
+  assert(g.argv.indexOf("--session-id") === -1, "pi buildRun never passes a caller session id (pi assigns its own)")
+
+  const gen = g.generation
+  AiBackend.handleLine(gen, '{"type":"session","version":3,"id":"01a0736b-5551-7689-99ae-b04e08489f3a","cwd":"/home/mark"}')
+  AiBackend.handleLine(gen, '{"type":"message_update","usage":{},"assistantMessageEvent":{"type":"thinking_delta","contentIndex":0,"delta":"hmm"}}')
+  AiBackend.handleLine(gen, '{"type":"message_update","usage":{},"assistantMessageEvent":{"type":"text_delta","contentIndex":1,"delta":"Hello"}}')
+  AiBackend.handleLine(gen, '{"type":"message_update","usage":{},"assistantMessageEvent":{"type":"text_delta","contentIndex":1,"delta":" world"}}')
+  AiBackend.handleExit(gen, 0)
+  const snap = drainToReady()
+  eq(snap.state, "ready", "pi session reaches Ready after its typewriter drain")
+  eq(snap.sessionRef, "01a0736b-5551-7689-99ae-b04e08489f3a", "pi sessionRef comes from the NDJSON session event")
+  eq(snap.rawText, "Hello world", "pi text_delta events accumulate into rawText (thinking deltas excluded)")
+
+  const resumeArgv = AiBackend.buildHandoffArgv()
+  assert(Array.isArray(resumeArgv), "pi handoff argv builds from Ready")
+  assert(resumeArgv.indexOf("--session-id") !== -1, "pi handoff resumes via --session-id")
+  assert(resumeArgv.indexOf("01a0736b-5551-7689-99ae-b04e08489f3a") !== -1, "pi handoff carries the captured session id")
+  assert(resumeArgv.indexOf("pi e2e test") === -1, "pi handoff argv never carries the prompt")
 }
 
 {


### PR DESCRIPTION
## Summary

Adds a **Pi** adapter to the AI search hub, so `ai <question>` works when **Pi** is the Omarchy default agent (`~/.config/omarchy/defaults/agent` = `pi`) or when `ai.json` sets `"agent": "pi"`.

Before this PR, Pi users got the *"pi does not yet support headless AI mode"* hint.

## What changed

| File | Change |
|---|---|
| `ai/AiAdapters.js` | New `piAdapter` (registered in `ADAPTERS`): runs `pi --mode json -p <prompt>` and parses pi's real NDJSON schema |
| `ai/AiConfig.js` | `SUPPORTED_AGENTS` now includes `pi` (ai.json validation + Omarchy default-agent auto-detection) |
| `ai/AiBackend.js` | Pi removed from the known-but-unsupported hint list; error text lists Pi as supported |
| `tests/ai_unit_test.js` | Pi added to the argv-safety and never-throws loops, plus adapter unit tests and a full end-to-end AiBackend flow |
| `README.md` | Pi added to the supported-agents table, default-agent instructions, and `ai.json` field docs |

## Adapter behavior (all verified against the real `pi` CLI)

- **Streaming:** `pi --mode json` emits clean NDJSON. The `session` event's `id` is the authoritative session ref; `message_update` → `assistantMessageEvent.type === "text_delta"` events are already incremental and are surfaced as answer text. `thinking_*` / `toolcall_*` deltas are surfaced as activity only, never as answer text. `turn_end`/`agent_end` carry the full answer as a `finalText` fallback (defense in depth, only used if no deltas arrived).
- **Terminal handoff:** resumes with `pi --session-id <id>`, which continues the exact session. Note: pi scopes sessions per project (working directory) — the overlay spawns with quickshell's cwd and the handoff terminal opens in `$HOME` via `xdg-terminal-exec --dir=`, and quickshell's service cwd is `$HOME`, so both sides resolve to the same project. Verified: same-directory create + `--session-id` resume carries context (`cacheRead`), cross-directory resume degrades to a fresh session with that id.
- **argv safety:** the prompt is bound as `-p`'s own value (same value-taking gotcha as agy's `--print`) and all options are grouped **before** `-p`; the prompt remains a single literal argv element (covered by the existing argv-safety loop + new tests).
- **Tool use:** like the other adapters, the agent runs in headless mode with its tools enabled — pi executes tool calls autonomously (no approval prompts). This matches the existing claude/codex/opencode adapters' behavior.

## Verification

- Full suite: **1376 passed, 0 failed** (1343 existing + 33 new).
- Live end-to-end: ran the adapter's exact `buildRun` argv against the real `pi` binary, fed the real NDJSON output through `parseLine`, and confirmed `session` capture, exact `text_delta` accumulation, and `finalText` fallback all match the actual answer.
- Session round-trip: created a session in `$HOME` (the shell's cwd), resumed via `pi --session-id <id>` from `$HOME` — same session id, context carried (no "creating a new session" warning).