### PR TITLE
feat(ui): wrap long queries in the search header instead of eliding

### DIFF
--- a/Find.qml
+++ b/Find.qml
@@ -100,6 +100,9 @@ Item {
   property int contentMargin: Style.spacing.panelPadding
   property int contentSpacing: Style.spacing.md
   property int headerHeight: Math.max(Style.space(34), Style.font.title + Style.spacing.controlPaddingY * 2)
+  // The query line wraps instead of eliding; the header (and the card with it)
+  // grows up to this many lines before the text starts eliding again.
+  property int searchMaxLines: 5
   // Safe clearance margins: guarantees the centered card never crowds or touches
   // screen edges, top/bottom bars, docks, or borders across resolutions and scale factors.
   readonly property int safeMarginY: panel && panel.height > 0
@@ -1094,19 +1097,19 @@ Item {
     BorderSurface {
       id: card
       width: root.cardWidth
-      readonly property int aiMaxBoxHeight: Math.max(0, root.cardHeight - root.headerHeight - root.aiChipRowHeight - footer.implicitHeight - root.contentSpacing * 3 - card.contentTopInset - card.contentBottomInset)
+      readonly property int aiMaxBoxHeight: Math.max(0, root.cardHeight - searchField.height - root.aiChipRowHeight - footer.implicitHeight - root.contentSpacing * 3 - card.contentTopInset - card.contentBottomInset)
       readonly property int aiBoxHeight: (root.aiSession && root.aiSession.state !== "idle" && aiAnswerText.text.length > 0)
         ? Math.min(card.aiMaxBoxHeight, aiAnswerText.implicitHeight + Style.spacing.sm * 2)
         : 0
       height: root.expanded
         ? (root.isGoogleSearch
             ? (root.googleSearchTerms !== ""
-                ? (root.headerHeight + root.rowHeight + footer.implicitHeight + root.contentSpacing * 2 + card.contentTopInset + card.contentBottomInset)
-                : (root.headerHeight + card.contentTopInset + card.contentBottomInset))
+                ? (searchField.height + root.rowHeight + footer.implicitHeight + root.contentSpacing * 2 + card.contentTopInset + card.contentBottomInset)
+                : (searchField.height + card.contentTopInset + card.contentBottomInset))
             : root.isAiMode
-              ? (root.headerHeight + root.aiChipRowHeight + card.aiBoxHeight + footer.implicitHeight + (card.aiBoxHeight > 0 ? root.contentSpacing * 3 : root.contentSpacing * 2) + card.contentTopInset + card.contentBottomInset)
+              ? (searchField.height + root.aiChipRowHeight + card.aiBoxHeight + footer.implicitHeight + (card.aiBoxHeight > 0 ? root.contentSpacing * 3 : root.contentSpacing * 2) + card.contentTopInset + card.contentBottomInset)
               : root.cardHeight)
-        : root.headerHeight + card.contentTopInset + card.contentBottomInset
+        : searchField.height + card.contentTopInset + card.contentBottomInset
       radius: root.cornerRadius
       anchors.centerIn: parent
 
@@ -1266,14 +1269,21 @@ Item {
         Rectangle {
           id: searchField
           width: parent.width
-          height: root.headerHeight
+          // Height of one rendered line of the query, used to keep the vertical
+          // padding the single-line header had while the text wraps.
+          readonly property real lineHeight: searchText.lineCount > 0
+            ? searchText.implicitHeight / searchText.lineCount
+            : searchText.implicitHeight
+          height: Math.max(root.headerHeight,
+                           Math.ceil(searchText.implicitHeight + root.headerHeight - lineHeight))
           radius: root.cornerRadius
           color: "transparent"
 
           Text {
             id: searchIcon
             anchors.left: parent.left
-            anchors.verticalCenter: parent.verticalCenter
+            anchors.top: parent.top
+            anchors.topMargin: Math.round((root.headerHeight - searchIcon.implicitHeight) / 2)
             text: "󰍉"
             textFormat: Text.PlainText
             color: root.accent
@@ -1282,6 +1292,7 @@ Item {
           }
 
           Text {
+            id: searchText
             anchors.left: searchIcon.right
             anchors.leftMargin: Style.spacing.sm
             anchors.right: expandButton.left
@@ -1293,6 +1304,8 @@ Item {
             opacity: root.filterText ? 1 : 0.58
             font.family: root.fontFamily
             font.pixelSize: Style.font.heading
+            wrapMode: Text.Wrap
+            maximumLineCount: Math.max(1, root.searchMaxLines)
             elide: Text.ElideRight
           }
 
@@ -1300,7 +1313,8 @@ Item {
             id: expandButton
             visible: !root.isGoogleSearch && !root.isAiMode
             anchors.right: parent.right
-            anchors.verticalCenter: parent.verticalCenter
+            anchors.top: parent.top
+            anchors.topMargin: Math.round((root.headerHeight - expandButton.height) / 2)
             width: expandLabel.implicitWidth + Style.space(18)
             height: Math.max(Style.space(26), Style.font.body + Style.space(10))
             radius: root.cornerRadius

--- a/Find.qml
+++ b/Find.qml
@@ -1117,7 +1117,11 @@ Item {
       radius: root.cornerRadius
       anchors.centerIn: parent
 
+      // A Behavior chasing a target that is itself animating lags behind it, so
+      // while the header grows the card tracks it frame for frame and only
+      // animates height changes of its own (expanding, the AI answer box).
       Behavior on height {
+        enabled: !searchFieldGrow.running
         NumberAnimation { duration: 180; easing.type: Easing.OutCubic }
       }
 
@@ -1296,9 +1300,15 @@ Item {
                  - root.contentSpacing * (countLabel.visible ? 5 : 4)
           }
           readonly property int maxLines: Math.max(1, Math.floor(Math.max(0, maxHeight - padding) / Math.max(1, lineHeight)))
-          height: Math.max(root.headerHeight, Math.ceil(searchFlick.height + padding))
+          readonly property int targetHeight: Math.max(root.headerHeight,
+            Math.ceil(Math.min(searchText.implicitHeight, maxLines * lineHeight) + padding))
+          height: targetHeight
           radius: root.cornerRadius
           color: "transparent"
+
+          Behavior on height {
+            NumberAnimation { id: searchFieldGrow; duration: 180; easing.type: Easing.OutCubic }
+          }
 
           Text {
             id: searchIcon
@@ -1319,7 +1329,7 @@ Item {
             anchors.right: expandButton.left
             anchors.rightMargin: Style.spacing.sm
             anchors.verticalCenter: parent.verticalCenter
-            height: Math.min(searchText.implicitHeight, searchField.maxLines * searchField.lineHeight)
+            height: Math.max(0, searchField.height - searchField.padding)
             contentWidth: width
             contentHeight: searchText.implicitHeight
             clip: true

--- a/Find.qml
+++ b/Find.qml
@@ -100,9 +100,13 @@ Item {
   property int contentMargin: Style.spacing.panelPadding
   property int contentSpacing: Style.spacing.md
   property int headerHeight: Math.max(Style.space(34), Style.font.title + Style.spacing.controlPaddingY * 2)
-  // The query line wraps instead of eliding; the header (and the card with it)
-  // grows up to this many lines before the text starts eliding again.
-  property int searchMaxLines: 5
+  // The query line wraps instead of eliding. It grows the header, and the card
+  // with it, until the card has no room left to give on this display, then
+  // scrolls. The budget is derived from cardHeight (itself clamped to the
+  // screen), so a smaller display or a larger font simply yields fewer lines.
+  // These two are what the header is not allowed to eat into.
+  property int searchMinVisibleRows: 3
+  property int aiMinAnswerHeight: rowHeight * 2
   // Safe clearance margins: guarantees the centered card never crowds or touches
   // screen edges, top/bottom bars, docks, or borders across resolutions and scale factors.
   readonly property int safeMarginY: panel && panel.height > 0
@@ -1269,13 +1273,30 @@ Item {
         Rectangle {
           id: searchField
           width: parent.width
-          // Height of one rendered line of the query, used to keep the vertical
-          // padding the single-line header had while the text wraps.
+          // Height of one rendered line of the query. Keeps the vertical padding
+          // the single-line header had, and lets the viewport grow whole lines.
           readonly property real lineHeight: searchText.lineCount > 0
             ? searchText.implicitHeight / searchText.lineCount
             : searchText.implicitHeight
-          height: Math.max(root.headerHeight,
-                           Math.ceil(searchText.implicitHeight + root.headerHeight - lineHeight))
+          readonly property real padding: Math.max(0, root.headerHeight - lineHeight)
+          // How tall the query may grow before it scrolls instead: everything the
+          // card can spare on this display, once the rows that have to stay
+          // visible under it are accounted for.
+          readonly property int maxHeight: {
+            var chrome = footer.implicitHeight + card.contentTopInset + card.contentBottomInset
+            if (root.isAiMode)
+              return root.cardHeight - chrome - root.aiChipRowHeight - root.aiMinAnswerHeight - root.contentSpacing * 3
+            if (root.isGoogleSearch)
+              return root.cardHeight - chrome - root.rowHeight - root.contentSpacing * 2
+            return root.cardHeight - chrome
+                 - (chips.visible ? chips.height : 0)
+                 - (sortBar.visible ? sortBar.height : 0)
+                 - (countLabel.visible ? countLabel.implicitHeight : 0)
+                 - root.rowHeight * root.searchMinVisibleRows
+                 - root.contentSpacing * (countLabel.visible ? 5 : 4)
+          }
+          readonly property int maxLines: Math.max(1, Math.floor(Math.max(0, maxHeight - padding) / Math.max(1, lineHeight)))
+          height: Math.max(root.headerHeight, Math.ceil(searchFlick.height + padding))
           radius: root.cornerRadius
           color: "transparent"
 
@@ -1291,22 +1312,34 @@ Item {
             font.pixelSize: Style.font.heading
           }
 
-          Text {
-            id: searchText
+          Flickable {
+            id: searchFlick
             anchors.left: searchIcon.right
             anchors.leftMargin: Style.spacing.sm
             anchors.right: expandButton.left
             anchors.rightMargin: Style.spacing.sm
             anchors.verticalCenter: parent.verticalCenter
-            text: root.filterText || Backend.t("searchPlaceholder", root.locale)
-            textFormat: Text.PlainText
-            color: root.foreground
-            opacity: root.filterText ? 1 : 0.58
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.heading
-            wrapMode: Text.Wrap
-            maximumLineCount: Math.max(1, root.searchMaxLines)
-            elide: Text.ElideRight
+            height: Math.min(searchText.implicitHeight, searchField.maxLines * searchField.lineHeight)
+            contentWidth: width
+            contentHeight: searchText.implicitHeight
+            clip: true
+            interactive: contentHeight > height
+            boundsBehavior: Flickable.StopAtBounds
+            // Typing only ever appends, so keep the tail of the query in view.
+            onContentHeightChanged: contentY = Math.max(0, contentHeight - height)
+            onHeightChanged: contentY = Math.max(0, contentHeight - height)
+
+            Text {
+              id: searchText
+              width: searchFlick.width
+              text: root.filterText || Backend.t("searchPlaceholder", root.locale)
+              textFormat: Text.PlainText
+              color: root.foreground
+              opacity: root.filterText ? 1 : 0.58
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.heading
+              wrapMode: Text.Wrap
+            }
           }
 
           Rectangle {


### PR DESCRIPTION
First, thank you for building this. Omarchy Find has become how I get around my machine, and the AI mode is genuinely the feature I didn't know I wanted. This is a small paper cut I ran into from using it a lot — please take or leave it as you see fit.

## The problem

The query line is a single elided `Text`, so anything wider than the card ends in `…`. In file search that rarely matters, since queries are short. In `ai <question>` mode the query is a sentence, and once it passes the card width you can't read back what you typed or check it before pressing Enter.

**Before**

![before](https://raw.githubusercontent.com/rdannenbring/omarchy-find/pr-assets/pr-before.png)

**After**

![after](https://raw.githubusercontent.com/rdannenbring/omarchy-find/pr-assets/pr-after.png)

## Three commits, in case you want only the first

**1. `wrap long queries in the search header instead of eliding`** — the minimal fix, +22/−8:

- `searchText` gets `wrapMode: Text.Wrap` and a `maximumLineCount`, so long queries wrap and then elide at a cap.
- `searchField.height` grows with the wrapped text. It derives the single-line height from `implicitHeight / lineCount`, so the vertical padding stays exactly what it was.
- The four `root.headerHeight` terms in `card.height` and `aiMaxBoxHeight` now read `searchField.height`, so the card grows with the header and the AI answer box is still measured against the real header height.
- The magnifier and the Collapse button pin to the first line instead of centering against a multi-line block.

This is complete on its own, and if you'd rather keep the diff small, it's the one to take.

**2. `scroll the query past what the card can fit`** — the part I'd argue for:

The cap in commit 1 is a hardcoded five lines, and a fixed line count has no idea how tall the screen is. On a short display, or with a large font, five lines plus the chip row plus the footer can push the AI card past `cardHeight`. So the cap becomes a budget: the header takes everything the card can spare, once the rows that have to stay visible under it are subtracted —

- **AI:** chip row, footer, and `aiMinAnswerHeight` (2 rows) kept for the answer
- **Browse:** chips, sort bar, count, footer, and `searchMinVisibleRows` (3) of results
- **`go`:** the single result row and the footer

and past that the query scrolls instead of eliding. The viewport is sized in whole lines and pinned to the tail — typing only ever appends, so the end of the query stays in view while the start scrolls off. Below, a query about four times the budget:

![scrolled](https://raw.githubusercontent.com/rdannenbring/omarchy-find/pr-assets/pr-scroll.png)

Because the budget comes from `cardHeight`, which is already `min(design height, screen − safe margins)`, this adapts on its own — a smaller display or a larger font simply yields fewer lines, with no separate logic. It also means the card can no longer outgrow itself, which commit 1 alone doesn't guarantee.

**3. `grow the header and the card in lockstep`** — the polish:

`card` already has a `Behavior on height`. Animating the header underneath it meant the card was chasing a target that was itself moving, which lags instead of tracking. So the field became the single animated value: it eases toward `targetHeight`, the query viewport is sized from that animated height rather than from the text, and the card's `Behavior` stands down (`enabled: !searchFieldGrow.running`) while the field animation runs. The card still animates its own height changes — expanding, and the answer box growing.

The viewport has to follow the animated height rather than the text: sized from the text, it jumped to full height while the container was still easing, and the new line overlapped the AI chip row for the length of the animation.

Verified frame by frame off a 60fps screen recording, slicing the card's border column out of each frame: two to four frames of travel per added line, top and bottom edges moving symmetrically on the same frames, an eased landing, and no overshoot or lag tail.

Short queries render exactly as before in all three commits: the field height is `Math.max(root.headerHeight, …)`, so nothing moves until the text actually wraps.

## Things I'd defer to you on

- `searchMinVisibleRows: 3` and `aiMinAnswerHeight: rowHeight * 2` are the two numbers I picked, sitting next to the other root properties. Happy to retune them, or expose a cap as a config key — `ai.json` already has `maxAnswerRows`, so a `maxQueryLines` alongside it would fit the existing pattern. I left it out because the header applies to all three modes while that file is AI-specific, and it's your config surface to decide on.
- Mouse-wheel scrolling of an overflowing query is stock `Flickable` behavior and I haven't driven a real pointer over it to confirm — the clipping, the tail-pinning, and the animation are what I verified.

Tested on Hyprland 0.56.2 at 1x on a 2560x1440 monitor, in file search, `go`, and `ai` modes, with queries from a few characters to roughly four times the budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
